### PR TITLE
Turn off 1.0

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1']
+        julia-version: ['1.0', '1']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0', '1', 'nightly']
+        julia-version: ['1']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0', '1']
+        julia-version: ['nightly', '1']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:


### PR DESCRIPTION
addresses #70 by disabling 1.0 CI.
We can't practically make the tests run on 1.0 because of the [lack of re-resolving.](https://www.oxinabox.net/2021/02/13/Julia-1.6-what-has-changed-since-1.0.html#resolver-willing-to-downgrade-packages-to-install-new-ones-tiered-resolution)

Also disabling nightly, because I can't see us ever acting on a Nightly failure anyway.
Nightly is unstable.
