### PR TITLE
Allow forcing reading the reference file as raw txt/string

### DIFF
--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -24,7 +24,8 @@ function savefile(file::TextFile, content)
     write(file.filename, string(content))
 end
 
-function query_extended(filename)
+function query_extended(filename, force_raw_txt = false)
+    force_raw_txt && return File{format"TXT"}(filename)
     file, ext = splitext(filename)
     # TODO: make this less hacky
     if uppercase(ext) == ".SHA256"

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -88,7 +88,7 @@ function test_reference(
     filename::AbstractString, raw_actual;
     by = nothing, render = nothing, format = nothing, kw...)
     format isa AbstractString && (format = FileIO.DataFormat{Symbol(format)})
-    reference_file = isnothing(format) ? query_extended(filename) : File{format}(filename)
+    reference_file = format === nothing ? query_extended(filename) : File{format}(filename)
     test_reference(reference_file, raw_actual, by, render; kw...)
 end
 

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -88,7 +88,7 @@ function test_reference(
     filename::AbstractString, raw_actual;
     by = nothing, render = nothing, format = nothing, kw...)
     format isa AbstractString && (format = FileIO.DataFormat{Symbol(format)})
-    reference_file = isnothing(format) ? query_extended(filename) : format(filename)
+    reference_file = isnothing(format) ? query_extended(filename) : File{format}(filename)
     test_reference(reference_file, raw_actual, by, render; kw...)
 end
 

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -16,6 +16,7 @@ Arguments:
 * `filename::String`: _relative_ path to the file that contains the macro invocation.
 * `expr`: the actual content used to compare.
 * `by`: the equality test function. By default it is `isequal` if not explicitly stated.
+* `force_raw_txt`: Force reading the file as a raw string
 
 # Types
 
@@ -85,9 +86,9 @@ end
 
 function test_reference(
     filename::AbstractString, raw_actual;
-    by = nothing, render = nothing, kw...)
+    by = nothing, render = nothing, force_raw_txt = false, kw...)
 
-    test_reference(query_extended(filename), raw_actual, by, render; kw...)
+    test_reference(query_extended(filename, force_raw_txt), raw_actual, by, render; kw...)
 end
 
 function test_reference(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using ImageInTerminal, TestImages, ImageCore, ImageTransformations
+using FileIO
 using Plots
 using Random
 
@@ -157,6 +158,13 @@ end
     @test isfile(newfilename)  # Was created
     @test_reference newfilename camera size=(5,10) # Matches expected content
     rm(newfilename, force=true)
+end
+
+@testset "format keyword" begin
+    file =  "references/camera.sha256"
+    raw_contents = read(file, String)
+    @test_reference file raw_contents format=format"TXT"
+    @test_reference file raw_contents format="TXT"
 end
 
 end  # top level testset


### PR DESCRIPTION
In `UnicodePlots`'s reference tests, some of the txt files were being erroneously detected as `Gadget2` filetypes, where they just needed to be parsed as raw txt/string files. 

This adds a kwarg to force that.

Used in the WIP https://github.com/Evizero/UnicodePlots.jl/pull/136