### PR TITLE
reduce CI workload

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    - cron: '20 00 1 * *'
 
 jobs:
   test:
@@ -17,7 +15,16 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ['1.0', '1', 'nightly']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest]
+        arch: [x64]
+        include:
+          - os: windows-latest
+            julia-version: '1'
+            arch: x64
+          - os: macOS-latest
+            julia-version: '1'
+            arch: x64
+
     env:
         REFERENCE_TESTS_STAGING_PATH: "~/mismatches/"
     steps:


### PR DESCRIPTION
Windows and macOS CI resources are quite expensive, I believe only test Julia 1.x should be sufficient enough. We still have Ubuntu CI for Julia 1.0 and Julia nightly.

- remove cron job
- only test macOS and Windows on Julia 1