### PR TITLE
Add psnr implementation for RGBA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReferenceTests"
 uuid = "324d217c-45ce-50fc-942e-d289b448e8cf"
 authors = ["Christof Stocker <stocker.christof@gmail.com>", "Lyndon White <oxinabox@ucc.asn.au>", "Johnny Chen <johnnychen94@hotmail.com>"]
-version = "0.9.8"
+version = "0.9.9"
 
 [deps]
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"

--- a/src/equality_metrics.jl
+++ b/src/equality_metrics.jl
@@ -52,8 +52,8 @@ end
 _psnr(ref::AbstractArray{<:Color3}, x::AbstractArray{<:Color3}) =
     _psnr(channelview(RGB.(ref)), channelview(RGB.(x)), 1.0)
 
-_psnr(ref::AbstractArray{<:ColorTypes.RGBA}, x::AbstractArray{<:ColorTypes.RGBA}) =
-    _psnr(channelview(ref), channelview(x), 1.0)
+_psnr(ref::AbstractArray{<:ColorTypes.Transparent3}, x::AbstractArray{<:ColorTypes.Transparent3}) =
+    _psnr(channelview(ARGB.(ref)), channelview(ARGB.(x)), 1.0)
 
 _psnr(ref::AbstractArray{<:AbstractGray}, x::AbstractArray{<:AbstractGray}) =
     _psnr(channelview(ref), channelview(x), 1.0)

--- a/src/equality_metrics.jl
+++ b/src/equality_metrics.jl
@@ -52,6 +52,9 @@ end
 _psnr(ref::AbstractArray{<:Color3}, x::AbstractArray{<:Color3}) =
     _psnr(channelview(RGB.(ref)), channelview(RGB.(x)), 1.0)
 
+_psnr(ref::AbstractArray{<:ColorTypes.RGBA}, x::AbstractArray{<:ColorTypes.RGBA}) =
+    _psnr(channelview(ref), channelview(x), 1.0)
+
 _psnr(ref::AbstractArray{<:AbstractGray}, x::AbstractArray{<:AbstractGray}) =
     _psnr(channelview(ref), channelview(x), 1.0)
 


### PR DESCRIPTION
This PR adds a psnr implementation for RGBA, following the similar psnr implementations.

Closes #102.
