### PR TITLE
Fix urls in README, remove `compat` table in `docs/Project.toml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ change for selected test cases.
 
 ## Documentation
 
-Check out the **[latest documentation][docs-latest-url]**
+Check out the **[stable documentation][docs-stable-url]** or **[dev documentation][docs-dev-url]**.
 
 Additionally, you can make use of Julia's native docsystem.
 The following example shows how to get additional information
@@ -110,5 +110,5 @@ This code is free to use under the terms of the MIT license.
 [codecov-url]: https://codecov.io/github/JuliaTesting/ReferenceTests.jl?branch=master
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
 [docs-stable-url]: https://JuliaTesting.github.io/ReferenceTests.jl/stable
-[docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
-[docs-latest-url]: https://JuliaTesting.github.io/ReferenceTests.jl/latest
+[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
+[docs-dev-url]: https://JuliaTesting.github.io/ReferenceTests.jl/dev

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
-
-[compat]
-Documenter = "0.24"


### PR DESCRIPTION
* Fixing the version of Documenter.jl may sometimes cause problems like [this](https://github.com/JuliaTesting/ReferenceTests.jl/issues/104#issuecomment-994914395).
  * I have just removed it.
* The latest documentation https://juliatesting.github.io/ReferenceTests.jl/latest/ is not the latest.
  * The `latest` was created with old Documenter, but it is now replaced with `dev`.
  * The link to `latest` should be redirected to `dev`, and I can fix this in other PR.
