### PR TITLE
Expose env var to force update failing ref tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,17 @@ test suite. These tests are easy to run via `pkg> test` but
 the child process used within `pkg> test` is non-interactive, so the
 update prompt will not show if there are mismatches.
 
-To update references within a package test suite, there are two options:
+To update references within a package test suite, there are three options:
 
-1. Set the environment variable `JULIA_REFERENCETESTS_UPDATE` to `"true"`
-   and run `pkg> test`, which will force update any non-matches. You can then
-   check changes to any git-tracked reference images before commit.
-2. Run the `test/runtests.jl` interactively. This may be easier using
-   the [`TestEnv.jl`](https://github.com/JuliaTesting/TestEnv.jl) package,
-   given that the test environment used by `pkg> test` is a merge of the
-   `src/Project.toml` and `test/Project.toml` environments.
+- Set the environment variable `JULIA_REFERENCETESTS_UPDATE` to `"true"`
+  and run `pkg> test`, which will force update any non-matches. You can then
+  check changes to any git-tracked reference images before commit.
+- Delete any reference images you wish to update and run `pkg> test`, given
+  that missing references are created automatically.
+- Run the `test/runtests.jl` interactively. This may be easier using
+  the [`TestEnv.jl`](https://github.com/JuliaTesting/TestEnv.jl) package,
+  given that the test environment used by `pkg> test` is a merge of the
+  `src/Project.toml` and `test/Project.toml` environments.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ compared as plain text. This is useful for a convenient
 low-storage way of making sure that the return value doesn't
 change for selected test cases.
 
+## Updating References within Package Tests
+
+Reference tests are typically used within a package's `test/runtests.jl`
+test suite. These tests are easy to run via `pkg> test` but
+the child process used within `pkg> test` is non-interactive, so the
+update prompt will not show if there are mismatches.
+
+To update references within a package test suite, there are two options:
+
+1. Set the environment variable `JULIA_REFERENCETESTS_UPDATE` to `"true"`
+   and run `pkg> test`, which will force update any non-matches. You can then
+   check changes to any git-tracked reference images before commit.
+2. Run the `test/runtests.jl` interactively. This may be easier using
+   the [`TestEnv.jl`](https://github.com/JuliaTesting/TestEnv.jl) package,
+   given that the test environment used by `pkg> test` is a merge of the
+   `src/Project.toml` and `test/Project.toml` environments.
+
 ## Documentation
 
 Check out the **[stable documentation][docs-stable-url]** or **[dev documentation][docs-dev-url]**.

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -168,7 +168,7 @@ function test_reference(
         )
         render(rendermode, reference, actual)
 
-        if isinteractive() && !force_update()
+        if !isinteractive() && !force_update()
             error("""
             To update the reference images either run the tests interactively with 'include(\"test/runtests.jl\")',
             or to force-update any failing reference images set the  environment variable `JULIA_REFERENCETESTS_UPDATE`

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -176,7 +176,7 @@ function test_reference(
             """)
         end
 
-        if force_update() || !input_bool("Replace reference with actual result?")
+        if !force_update() && !input_bool("Replace reference with actual result?")
             @test false
         else
             mv(actual_path, reference_path; force=true)  # overwrite old file it

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -176,11 +176,11 @@ function test_reference(
             """)
         end
 
-        if !force_update() && !input_bool("Replace reference with actual result?")
-            @test false
-        else
+        if force_update() || input_bool("Replace reference with actual result?")
             mv(actual_path, reference_path; force=true)  # overwrite old file it
             @info("Please run the tests again for any changes to take effect")
+        else
+            @test false
         end
     end
 end

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -171,7 +171,7 @@ function test_reference(
         if !isinteractive() && !force_update()
             error("""
             To update the reference images either run the tests interactively with 'include(\"test/runtests.jl\")',
-            or to force-update any failing reference images set the  environment variable `JULIA_REFERENCETESTS_UPDATE`
+            or to force-update all failing reference images set the environment variable `JULIA_REFERENCETESTS_UPDATE`
             to "true" and re-run the tests via Pkg.
             """)
         end

--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -168,11 +168,15 @@ function test_reference(
         )
         render(rendermode, reference, actual)
 
-        if !isinteractive()
-            error("You need to run the tests interactively with 'include(\"test/runtests.jl\")' to update reference images")
+        if isinteractive() && !force_update()
+            error("""
+            To update the reference images either run the tests interactively with 'include(\"test/runtests.jl\")',
+            or to force-update any failing reference images set the  environment variable `JULIA_REFERENCETESTS_UPDATE`
+            to "true" and re-run the tests via Pkg.
+            """)
         end
 
-        if !input_bool("Replace reference with actual result?")
+        if force_update() || !input_bool("Replace reference with actual result?")
             @test false
         else
             mv(actual_path, reference_path; force=true)  # overwrite old file it
@@ -180,6 +184,8 @@ function test_reference(
         end
     end
 end
+
+force_update() = tryparse(Bool, get(ENV, "JULIA_REFERENCETESTS_UPDATE", "false")) === true
 
 """
     mismatch_staging_dir()


### PR DESCRIPTION
I think this closes #8 

- [x] Add to docs