### PR TITLE
lazily load feature packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,17 +4,20 @@ authors = ["Christof Stocker <stocker.christof@gmail.com>", "Lyndon White <oxina
 version = "0.9.11"
 
 [deps]
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
+LazyModules = "8cdb02fc-e678-4876-92c5-9defec4f444e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 BSON = "0.3"
+Colors = "0.10, 0.11, 0.12"
 CSVFiles = "1"
 DataFrames = "0.21, 0.22"
 DeepDiffs = "1.1"
@@ -25,6 +28,7 @@ ImageCore = "0.8.1, 0.9"
 ImageInTerminal = "0.3, 0.4"
 ImageMagick = "0.7, 1"
 ImageTransformations = "0.8"
+LazyModules = "0.2"
 Plots = "= 1.4.3"
 TestImages = "0.6, 1"
 julia = "1"

--- a/src/ReferenceTests.jl
+++ b/src/ReferenceTests.jl
@@ -1,10 +1,13 @@
 module ReferenceTests
 
+using LazyModules
+
 using Test
-using ImageCore
+using Colors
 using Distances
 using FileIO
-using ImageInTerminal
+@lazy import ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+@lazy import ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
 using SHA
 using DeepDiffs
 using Random

--- a/src/equality_metrics.jl
+++ b/src/equality_metrics.jl
@@ -50,13 +50,13 @@ end
 
 # a simplified PSNR is sufficient since we only use it to approximately compare two images
 _psnr(ref::AbstractArray{<:Color3}, x::AbstractArray{<:Color3}) =
-    _psnr(channelview(RGB.(ref)), channelview(RGB.(x)), 1.0)
+    _psnr(ImageCore.channelview(RGB.(ref)), ImageCore.channelview(RGB.(x)), 1.0)
 
 _psnr(ref::AbstractArray{<:ColorTypes.Transparent3}, x::AbstractArray{<:ColorTypes.Transparent3}) =
-    _psnr(channelview(ARGB.(ref)), channelview(ARGB.(x)), 1.0)
+    _psnr(ImageCore.channelview(ARGB.(ref)), ImageCore.channelview(ARGB.(x)), 1.0)
 
 _psnr(ref::AbstractArray{<:AbstractGray}, x::AbstractArray{<:AbstractGray}) =
-    _psnr(channelview(ref), channelview(x), 1.0)
+    _psnr(ImageCore.channelview(ref), ImageCore.channelview(x), 1.0)
 
 _psnr(ref::AbstractArray{<:Real}, x::AbstractArray{<:Real}, peakval::Real) =
     20log10(peakval) - 10log10(_mse(float.(ref), float.(x)))

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -79,7 +79,8 @@ _convert(::Type{DataFormat{:SHA256}}, x; kw...) = bytes2hex(sha256(string(x)))
 function _convert(::Type{DataFormat{:SHA256}}, img::AbstractArray{<:Colorant}; kw...)
     # encode image into SHA256
     size_str = bytes2hex(sha256(reinterpret(UInt8,[map(Int64,size(img))...])))
-    img_str = bytes2hex(sha256(reinterpret(UInt8,vec(rawview(channelview(img))))))
+    img_bytes = vec(ImageCore.rawview(ImageCore.channelview(img)))
+    img_str = bytes2hex(sha256(reinterpret(UInt8, img_bytes)))
 
     return size_str * img_str
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,8 @@
 using Test
-using ImageInTerminal, TestImages, ImageCore, ImageTransformations
-using BSON:BSON
 using FileIO
-using Plots
+using BSON: BSON
 using Random
+using ReferenceTests
 
 if isinteractive()
     @info ("In interactive use, one should respond \"n\" when the program"
@@ -12,17 +11,20 @@ else
     @info ("Ten tests should correctly report failure in the transcript"
            * " (but not the test summary).")
 end
-# check for ambiguities
-refambs = detect_ambiguities(ImageInTerminal, Base, Core)
 
-using ReferenceTests
-ambs = detect_ambiguities(ReferenceTests, ImageInTerminal, Base, Core)
+
+ambs = detect_ambiguities(ReferenceTests, Base, Core)
+@test isempty(ambs)
+
+# to properly test world age issues, the full test dependencies must be loaded later
+include("test_no_world_age_issues.jl")
+
+using ImageInTerminal, TestImages, ImageCore, ImageTransformations
+using Plots
 
 strip_summary(content::String) = join(split(content, "\n")[2:end], "\n")
 
 @testset "ReferenceTests" begin
-
-@test Set(setdiff(ambs, refambs)) == Set{Tuple{Method,Method}}()
 
 # load/create some example images
 lena = testimage("lena_color_256")

--- a/test/test_no_world_age_issues.jl
+++ b/test/test_no_world_age_issues.jl
@@ -1,0 +1,7 @@
+@testset "world age issues" begin
+    files = ["references/camera.png"]
+
+    for filename in files
+        @test_reference filename load(joinpath(@__DIR__, filename))
+    end
+end


### PR DESCRIPTION
Lazily load ImageCore and ImageInTerminal using my newly written tool LazyModules.jl

This cuts the package loading latency from

```julia
julia> @time_imports using ReferenceTests
      0.6 ms    ┌ Compat
      0.4 ms    ┌ NaNMath
      0.3 ms      ┌ Adapt
     33.8 ms      ┌ OffsetArrays
     35.5 ms    ┌ PaddedViews
     20.6 ms    ┌ FixedPointNumbers
     42.5 ms      ┌ ChainRulesCore
     43.4 ms    ┌ ChangesOfVariables
      5.3 ms    ┌ AbstractFFTs
      0.3 ms    ┌ OpenLibm_jll
      1.4 ms      ┌ StackViews
      2.0 ms      ┌ MappedArrays
      4.3 ms    ┌ MosaicViews
      0.5 ms    ┌ InverseFunctions
      0.1 ms    ┌ Reexport
      4.3 ms    ┌ DocStringExtensions 68.85% compilation time
     98.8 ms      ┌ ColorTypes 4.71% compilation time
     84.2 ms      ┌ Colors
    185.2 ms    ┌ Graphics 2.51% compilation time
      3.1 ms    ┌ IrrationalConstants
      0.4 ms    ┌ TensorCore
      0.7 ms      ┌ LogExpFunctions
     14.4 ms          ┌ Preferences
     15.0 ms        ┌ JLLWrappers
    143.5 ms      ┌ OpenSpecFun_jll 89.07% compilation time (98% recompilation)
    174.3 ms    ┌ SpecialFunctions 73.33% compilation time (98% recompilation)
     87.4 ms    ┌ ColorVectorSpace 5.54% compilation time
    811.2 ms  ┌ ImageCore 18.82% compilation time (82% recompilation)
      0.4 ms  ┌ Requires
      0.3 ms    ┌ StatsAPI
      4.4 ms  ┌ Distances
     24.5 ms    ┌ Crayons
     30.8 ms    ┌ ImageBase
     90.2 ms  ┌ ImageInTerminal 11.81% compilation time (16% recompilation)
      2.7 ms  ┌ DeepDiffs
     72.4 ms  ┌ FileIO 8.02% compilation time
   1042.8 ms  ReferenceTests 16.22% compilation time (75% recompilation)
```

to

```julia
julia> @time_imports using ReferenceTests
      0.8 ms  ┌ LazyModules
      0.4 ms  ┌ Requires
      0.5 ms    ┌ StatsAPI
      3.4 ms  ┌ Distances
     22.6 ms  ┌ FixedPointNumbers
      0.2 ms  ┌ Reexport
      1.3 ms  ┌ DeepDiffs
     68.3 ms  ┌ FileIO 10.21% compilation time (21% recompilation)
     94.6 ms  ┌ ColorTypes 4.88% compilation time
     60.3 ms  ┌ Colors
    332.7 ms  ReferenceTests 6.82% compilation time (7% recompilation)
```

The caveats is world-age issues due to the dynamic lazy loading, thus a world-age issue test is added. Hopefully, it catches the issue in the long run.

The test time `time julia-latest --startup=no --project=. -e 'using Pkg; Pkg.test()'` is still ~35s