### PR TITLE
Fail test instead of erroring out when not interactive or updating

### DIFF
--- a/src/test_reference.jl
+++ b/src/test_reference.jl
@@ -162,14 +162,13 @@ function test_reference(
         """ reference = reference_path actual = actual_path
         
         if !isinteractive() && !force_update()
-            error("""
+            @info """
             To update the reference images either run the tests interactively with 'include(\"test/runtests.jl\")',
             or to force-update all failing reference images set the environment variable `JULIA_REFERENCETESTS_UPDATE`
             to "true" and re-run the tests via Pkg.
-            """)
-        end
-
-        if force_update() || input_bool("Replace reference with actual result?")
+            """
+            @test false
+        elseif force_update() || input_bool("Replace reference with actual result?")
             mv(actual_path, reference_path; force=true)  # overwrite old file it
             @info "Please run the tests again for any changes to take effect"
         else


### PR DESCRIPTION
Admittedly, I don't understand all the subtleties of how people want these tests to work, so maybe this won't work for others.  But for me, when a test fails in non-interactive non-updating mode, I still want to see all of the failures rather than just getting the whole testing framework to error out.
